### PR TITLE
Feature/issue 66 whitelist cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,10 @@ dependencies {
 	// mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	// cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation group: 'net.sf.ehcache', name: 'ehcache', version: '2.10.8'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 }

--- a/src/main/java/com/example/wegather/config/CacheConfig.java
+++ b/src/main/java/com/example/wegather/config/CacheConfig.java
@@ -1,0 +1,10 @@
+package com.example.wegather.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+}

--- a/src/main/java/com/example/wegather/global/HealthCheckController.java
+++ b/src/main/java/com/example/wegather/global/HealthCheckController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthCheckController {
-  @GetMapping("/health")
+  @GetMapping("/api/health")
   public ResponseEntity<String> health() {
     return ResponseEntity.ok("ok");
   }

--- a/src/main/java/com/example/wegather/interest/domain/InterestService.java
+++ b/src/main/java/com/example/wegather/interest/domain/InterestService.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -16,7 +17,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class InterestService {
-
+  private static final String GET_WHITELIST_CACHE_NAME = "getInterestWhiteList";
   private final InterestRepository interestRepository;
 
   /**
@@ -25,6 +26,7 @@ public class InterestService {
    * @return 생성된 관심사
    * @throws IllegalArgumentException 관심사 이름이 이미 존재하는 경우 예외를 던집니다.
    */
+  @CacheEvict(value = GET_WHITELIST_CACHE_NAME, allEntries = true)
   public Interest addInterest(CreateInterestRequest request) {
 
     boolean isNameExists = interestRepository.existsByName(request.getInterestName());
@@ -56,8 +58,9 @@ public class InterestService {
    * 관심사 화이트리스트를 조회합니다.
    * @return
    */
-  @Cacheable(value = "getInterestWhiteList")
+  @Cacheable(value = GET_WHITELIST_CACHE_NAME)
   public List<String> getInterestWhiteList() {
+    log.info("## uncached ##");
     return interestRepository.findAll().stream().map(Interest::getName).collect(Collectors.toList());
   }
 
@@ -76,6 +79,7 @@ public class InterestService {
    * id에 해당하는 관심사를 삭제합니다.
    * @param id
    */
+  @CacheEvict(value = GET_WHITELIST_CACHE_NAME, allEntries = true)
   public void deleteInterest(Long id) {
     interestRepository.deleteById(id);
   }

--- a/src/main/java/com/example/wegather/interest/domain/InterestService.java
+++ b/src/main/java/com/example/wegather/interest/domain/InterestService.java
@@ -8,8 +8,11 @@ import com.example.wegather.interest.dto.InterestDto;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class InterestService {
@@ -53,6 +56,7 @@ public class InterestService {
    * 관심사 화이트리스트를 조회합니다.
    * @return
    */
+  @Cacheable(value = "getInterestWhiteList")
   public List<String> getInterestWhiteList() {
     return interestRepository.findAll().stream().map(Interest::getName).collect(Collectors.toList());
   }

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -1,0 +1,16 @@
+<ehcache>
+  <diskStore path="java.io.tmpdir"/>
+
+  <defaultCache
+    maxElementsInMemory="10000"
+    eternal="false"
+    timeToIdleSeconds="120"
+    timeToLiveSeconds="120"
+    overflowToDisk="true"
+    maxElementsOnDisk="10000000"
+    diskPersistent="false"
+    diskExpiryThreadIntervalSeconds="120"
+    memoryStoreEvictionPolicy="LRU"
+  />
+
+</ehcache>

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -13,4 +13,12 @@
     memoryStoreEvictionPolicy="LRU"
   />
 
+  <cache name="getInterestWhiteList"
+    maxElementsInMemory="10"
+    eternal="false"
+    overflowToDisk="false"
+    timeToIdleSeconds="300"
+    timeToLiveSeconds="600"
+    memoryStoreEvictionPolicy="LRU" />
+
 </ehcache>


### PR DESCRIPTION
## 변경사항
> whitelist 조회를 캐시하여 성능 향상

## 상세 변경 사항
- 캐시 의존성 추가
   - Spring Cache 의존성, 설정 추가
   - Ehcache 의존성, 설정 추가 
- GET /api/interest/whtelist  결과 캐시
- Cache Invalidation
   - 관심사 추가, 삭제 시 캐시 무효화 

## 부하테스트 결과
- TPS : 256 → 2353 **(약 10배 개선)**
- Mean Test Time : 14.9 ms → 1.5 ms **(약 10배 감소)**
- 처리수 : 약 13,000 건 → 123,000 건 **(약 10배 증가)**

## 캐시 전
<img width="627" alt="image" src="https://github.com/prebird/weGather/assets/78974381/704a439e-be38-4b9f-bbc6-dc49dd11aad4">

## 캐시 후
<img width="641" alt="image" src="https://github.com/prebird/weGather/assets/78974381/af37887c-0313-430d-8007-6d682175568d">

