### PR TITLE
테스트간, ehcache manager 중복 등록 에러 해결

### DIFF
--- a/src/main/java/com/example/wegather/config/CacheConfig.java
+++ b/src/main/java/com/example/wegather/config/CacheConfig.java
@@ -1,10 +1,19 @@
 package com.example.wegather.config;
 
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 
 @EnableCaching
 @Configuration
 public class CacheConfig {
-
+  @Bean
+  public EhCacheManagerFactoryBean ehCacheCacheManager() {
+    EhCacheManagerFactoryBean cmfb = new EhCacheManagerFactoryBean();
+    cmfb.setConfigLocation(new ClassPathResource("ehcache.xml"));
+    cmfb.setShared(true);
+    return cmfb;
+  }
 }


### PR DESCRIPTION
# 변경 사항
- EhCacheManagerFactoryBean 를 customize 하기 위한 빈 등록
- EhCacheManagerFactoryBean 설정에 같은 이름의 매니저 팩토리 빈이 있으면 공유하는, shared = true 설정 추가

# 변경 이유
- 테스트 간, 컨텍스트가 공유될 때, EhCacheManagerFactoryBean 가 삭제 되지 않고 새로 생성되어 아래 에러 발생
`[Another unnamed CacheManager already exists in the same VM]`

# 참고
https://stackoverflow.com/questions/10013288/another-unnamed-cachemanager-already-exists-in-the-same-vm-ehcache-2-5